### PR TITLE
Fix daemon bootstrap

### DIFF
--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -91,7 +91,7 @@ class AppSettings():
     default_settings = {
         "daemon": {
             "log_level": 0,
-            "block_sync_size": 20,
+            "block_sync_size": 50,
             "limit_rate_up": 2048,
             "limit_rate_down": 8192,
             "use_boostrap_daemon": True,

--- a/html/index.py
+++ b/html/index.py
@@ -394,7 +394,7 @@ html =u"""
         <script src="./scripts/jquery.qrcode.min.js"></script>
         <script src="./scripts/utils.js"></script>
         <script type="text/javascript">
-            var block_sync_size = 20;
+            var block_sync_size = 50;
             function app_ready(){
                 setTimeout(app_hub.load_app_settings, 2000);
                 app_hub.on_load_app_settings_completed_event.connect(function(app_settings_json){
@@ -1440,13 +1440,13 @@ html =u"""
                                             </div>
                                             <div class="radio">
                                               <label>
-                                                <input type="radio" name="daemon_block_sync_size" id="block_sync_size_20" value="20" onclick="set_block_sync_size(20)" checked="">
+                                                <input type="radio" name="daemon_block_sync_size" id="block_sync_size_20" value="20" onclick="set_block_sync_size(20)">
                                                 20 (default, for normal network)
                                               </label>
                                             </div>
                                             <div class="radio">
                                               <label>
-                                                <input type="radio" name="daemon_block_sync_size" id="block_sync_size_50" value="50" onclick="set_block_sync_size(50)">
+                                                <input type="radio" name="daemon_block_sync_size" id="block_sync_size_50" value="50" onclick="set_block_sync_size(50)" checked="">
                                                 50 (for good network)
                                               </label>
                                             </div>
@@ -1494,7 +1494,7 @@ html =u"""
                                             </select>
                                         </div>
                                         <div class="col-xs-12" style="margin-top: 20px; margin-bottom: 10px;">
-                                            <input id="use_boostrap_daemon_chk" type="checkbox" value="" checked="checked"> <label class="control-label" for="use_boostrap_daemon_chk">Use boostrap daemon (auto)</label>
+                                            <input id="use_boostrap_daemon_chk" type="checkbox" value="" checked="checked"> <label class="control-label" for="use_boostrap_daemon_chk">Use bootstrap daemon (auto)</label>
                                         </div>
                                     </div>
                                 </form>

--- a/manager/ProcessManager.py
+++ b/manager/ProcessManager.py
@@ -56,10 +56,10 @@ class ProcessManager(Thread):
 
 
 class SumokoindManager(ProcessManager):
-    def __init__(self, resources_path, log_level=1, block_sync_size=20, limit_rate_up=2048, limit_rate_down=8192, use_bootstrap_daemon=True):
+    def __init__(self, resources_path, log_level=0, block_sync_size=50, limit_rate_up=2048, limit_rate_down=8192, use_boostrap_daemon=True):
         exec_path = u'%s/bin/sumokoind' % resources_path
         proc_args = u'--log-level=%d --block-sync-size=%d --limit-rate-up=%d --limit-rate-down=%d' % (log_level, block_sync_size, limit_rate_up, limit_rate_down)
-        if use_bootstrap_daemon:
+        if use_boostrap_daemon:
             proc_args += u' --bootstrap-daemon-address=auto'
         super(SumokoindManager, self).__init__(exec_path, proc_args, "sumokoind")
 


### PR DESCRIPTION
There was a typing mistake with **use_bootstrap_daemon** variable preventing it to work properly. It was typed correctly on ProcessManager.py but typed as **use_boostrap_daemon** at the rest of the code files. Instead of correcting every instance of the boolean along the code i 've just used the mistyped variable on ProcessManage.py as well. 

Fixed the default log level as well to 0 to correspond with the actual default setting, increased the default block sync size to 50 as per our core and fixed the same typo on the checkbox description on "use bootstrap"